### PR TITLE
changes ordering of vouchers

### DIFF
--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -1,7 +1,7 @@
 class Admin::HomeController < Admin::BaseController
   def index
     @swap = Swap.current
-    @vouchers = Voucher.order(created_at: :desc).last(20)
+    @vouchers = Voucher.order(created_at: :asc).last(20)
     @motel_map = Motel.all.pluck(:id, :name).to_h
 
     if @swap


### PR DESCRIPTION
Just reading from some Active Record documentation that: 

"If not specified, ordering will be performed in ascending order," but I wonder if by being explicit we help keep things readable? 