### PR TITLE
Limit hotels view of incident reports to only hotels they are assoc'd

### DIFF
--- a/app/controllers/hotels/vouchers_controller.rb
+++ b/app/controllers/hotels/vouchers_controller.rb
@@ -1,7 +1,7 @@
 class Hotels::VouchersController < Hotels::BaseController
   def show
     @voucher = Voucher.find(params[:id])
-    @incidents = @voucher.client.incident_reports
+    @incidents = @voucher.client.incident_reports.where(hotel: current_user.hotels)
     @incident_report = IncidentReport.new
 
     @client = @voucher.client


### PR DESCRIPTION
Currently, hotels can see all incident reports related to a client, instead of just the ones for hotels they are privy to.