### PR TITLE
Fix staging environment

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -24,8 +24,8 @@ default: &default
 development:
   <<: *default
   database: swapp_development
-  username: postgres
-  password: postgres
+  # username: postgres
+  # password: postgres
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -60,8 +60,8 @@ development:
 test:
   <<: *default
   database: swapp_test
-  username: postgres
-  password: postgres
+  # username: postgres
+  # password: postgres
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -85,5 +85,5 @@ test:
 production:
   <<: *default
   database: swapp_production
-  username: swapp
-  password: <%= ENV['swapp_DATABASE_PASSWORD'] %>
+  # username: swapp
+  # password: <%= ENV['swapp_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
`swapp-staging-1` app - postgres was upgraded from the free tier to Mini $5/month

Receiving error suggesting either missing database or lack of db user connectivity
`relation “hotels” was not found`

Looks like postgres exists, but maybe database needs to be re-created.
`$ rails db:create` results in..
`PG::ConnectionBad: connection to server at "3.211.6.217", port 5432 failed: FATAL: permission denied for database "postgres”`